### PR TITLE
Update аccount type detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -452,13 +452,11 @@ else
     warn "$(msg "cf_not_confirmed")"
 fi
 
-if [[ -f wgcf-account.toml ]]; then
-    wgcf_account_type=$(grep -oP '(?<=account_type = ")[^"]*' wgcf-account.toml 2>/dev/null)
-    if [[ "$wgcf_account_type" == "plus" ]]; then
-        ok "$(msg "warp_plus_active")"
-    else
-        info "$(msg "warp_free_active")"
-    fi
+wgcf_account_type=$(wgcf status &>/dev/null | grep -i "Account type" | awk -F': ' '{print $2}' | xargs)
+if [[ "$wgcf_account_type" == "unlimited" ]]; then
+    ok "$(msg "warp_plus_active")"
+elif [[ -n "$wgcf_account_type" ]]; then
+    info "$(msg "warp_free_active")"
 fi
 echo ""
 

--- a/install.sh
+++ b/install.sh
@@ -452,7 +452,7 @@ else
     warn "$(msg "cf_not_confirmed")"
 fi
 
-wgcf_account_type=$(wgcf status | grep -i "Account type" | awk -F': ' '{print $2}' | xargs)
+wgcf_account_type=$(wgcf status 2>/dev/null | grep -i "Account type" | awk -F': ' '{print $2}' | xargs)
 if [[ "$wgcf_account_type" == "unlimited" ]]; then
     ok "$(msg "warp_plus_active")"
 elif [[ -n "$wgcf_account_type" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -452,7 +452,7 @@ else
     warn "$(msg "cf_not_confirmed")"
 fi
 
-wgcf_account_type=$(wgcf status &>/dev/null | grep -i "Account type" | awk -F': ' '{print $2}' | xargs)
+wgcf_account_type=$(wgcf status | grep -i "Account type" | awk -F': ' '{print $2}' | xargs)
 if [[ "$wgcf_account_type" == "unlimited" ]]; then
     ok "$(msg "warp_plus_active")"
 elif [[ -n "$wgcf_account_type" ]]; then


### PR DESCRIPTION
Так как wgcf-account.toml файл не содержит в себе поле Account type, нужно проверять тип аккаунта через wgcf status с последующим парсингом поля из вывода. "unlimited" будет означать warp+

До:
<img width="456" height="61" alt="image" src="https://github.com/user-attachments/assets/ac02c4c8-16a4-4051-9b21-a5fff2201630" />
После:
<img width="489" height="66" alt="image" src="https://github.com/user-attachments/assets/63afb8e5-54f4-41e8-8425-47016f92cff0" />
